### PR TITLE
Weston 22

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,6 +2,7 @@ class Admin::DashboardController < ApplicationController
 
   def index
     @top_5 = Customer.top_5_by_transactions
+    @incomplete = Invoice.incomplete
   end
   
 end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,0 +1,6 @@
+class Admin::InvoicesController < ApplicationController
+
+  def show
+    @invoice = Invoice.find(params[:id])
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -4,4 +4,10 @@ class Invoice < ApplicationRecord
   has_many :transactions
   has_many :invoice_items
   has_many :items, through: :invoice_items
+
+
+  def self.incomplete
+    joins(:invoice_items)
+    .where("invoice_items.status != ?", 2)   
+  end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -6,8 +6,15 @@
  <p> <%= link_to "Admin Merchants", '/admin/merchants' %> </p>
  <p> <%= link_to "Admin Invoices", '/admin/invoices' %> </p>
 
- <p> Top 5 Customers:</p>
+ <h3> Top 5 Customers:</h3>
   <%@top_5.each do |customer|%>
     <p> <%= "#{customer.first_name + " " + customer.last_name}: #{customer.transaction_count} transactions"%> </p>
+  <% end %>
+</div>
+
+<div id='incomplete_invoices'>
+  <h3> Incomplete Invoices:</h3>
+  <% @incomplete.each do |invoice| %>
+    <p>id: <%= link_to "#{invoice.id}", "admin/invoices/#{invoice.id}" %> </p>
   <% end %>
 </div>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,0 +1,1 @@
+<h1> Invoice id: <%= @invoice.id %> Show Page </h1>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,1 +1,7 @@
 <h1> Invoice id: <%= @invoice.id %> Show Page </h1>
+
+<p><%= 'id: ' + @invoice.id.to_s %></p>
+<p><%= 'customer_id: ' + @invoice.customer_id.to_s %></p>
+<p><%= 'status: ' + @invoice.status %></p>
+<p><%= 'created_at: ' + @invoice.created_at.to_s %></p>
+<p><%= 'updated_at: ' + @invoice.updated_at.to_s %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get '/', to: 'dashboard#index'
+    resources :invoices, only: [:show]
     resources :merchants, only: [:index, :show, :new, :create]
   end
 

--- a/spec/features/admin/dashboard/dashboard_spec.rb
+++ b/spec/features/admin/dashboard/dashboard_spec.rb
@@ -86,7 +86,7 @@ describe 'dashboard' do
     end
     it 'should have a list of invoices that have unshipped items' do
       visit '/admin'
-      within ('div#incomplete_invoices')
+      within ('div#incomplete_invoices') do
         expect(page).to have_content("Incomplete Invoices")
         expect(page).to have_content("id: #{@invoice2.id}")
         expect(page).to have_content("id: #{@invoice4.id}")
@@ -96,10 +96,10 @@ describe 'dashboard' do
 
     it 'should have links to invoices admin show page' do
       visit '/admin'
-      within ('div#incomplete_invoices')
-        click_on " #{@invoice2.id}"
+      within ('div#incomplete_invoices') do
+        click_on "#{@invoice2.id}"
       end
-      expect(current_path).to eq("/admin/#{@invoice2.id}")
+      expect(current_path).to eq("/admin/invoices/#{@invoice2.id}")
     end
   end
   

--- a/spec/features/admin/dashboard/dashboard_spec.rb
+++ b/spec/features/admin/dashboard/dashboard_spec.rb
@@ -65,6 +65,43 @@ describe 'dashboard' do
       expect(page).to have_content("#{@customer5.first_name + " " + @customer5.last_name}: 2 transactions")
     end
   end
+
+  describe 'user story 22' do
+
+    before do
+      @customer = create(:customer)
+      @invoice1 = create(:invoice, customer_id: @customer.id)
+      @invoice2 = create(:invoice, customer_id: @customer.id)
+      @invoice3 = create(:invoice, customer_id: @customer.id)
+      @invoice4 = create(:invoice, customer_id: @customer.id)
+      @invoice5 = create(:invoice, customer_id: @customer.id)
+      @merchant = create(:merchant)
+      @item = create(:item, merchant_id: @merchant.id)
+      #StatusKey: 0 => packaged, 1 => pending, 2 => shipped
+      @invoice_item1 = create(:invoice_item, invoice_id: @invoice1.id, item_id: @item.id, status: 2)
+      @invoice_item2 = create(:invoice_item, invoice_id: @invoice2.id, item_id: @item.id, status: 0)
+      @invoice_item3 = create(:invoice_item, invoice_id: @invoice3.id, item_id: @item.id, status: 2)
+      @invoice_item4 = create(:invoice_item, invoice_id: @invoice4.id, item_id: @item.id, status: 0)
+      @invoice_item5 = create(:invoice_item, invoice_id: @invoice5.id, item_id: @item.id, status: 1)
+    end
+    it 'should have a list of invoices that have unshipped items' do
+      visit '/admin'
+      within ('div#incomplete_invoices')
+        expect(page).to have_content("Incomplete Invoices")
+        expect(page).to have_content("id: #{@invoice2.id}")
+        expect(page).to have_content("id: #{@invoice4.id}")
+        expect(page).to have_content("id: #{@invoice5.id}")
+      end
+    end
+
+    it 'should have links to invoices admin show page' do
+      visit '/admin'
+      within ('div#incomplete_invoices')
+        click_on " #{@invoice2.id}"
+      end
+      expect(current_path).to eq("/admin/#{@invoice2.id}")
+    end
+  end
   
 
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+
+describe 'admin invoice show page' do
+
+  it 'has a header saying it is a show page' do
+    customer = create(:customer)
+    invoice = create(:invoice, customer_id: customer.id)
+    visit "/admin/invoices/#{invoice.id}"
+    expect(page).to have_content("Invoice id: #{invoice.id} Show Page")
+  end
+end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -3,10 +3,22 @@ require 'rails_helper'
 
 describe 'admin invoice show page' do
 
+  before do 
+    @customer = create(:customer)
+    @invoice = create(:invoice, customer_id: @customer.id)
+  end
   it 'has a header saying it is a show page' do
-    customer = create(:customer)
-    invoice = create(:invoice, customer_id: customer.id)
-    visit "/admin/invoices/#{invoice.id}"
-    expect(page).to have_content("Invoice id: #{invoice.id} Show Page")
+    visit "/admin/invoices/#{@invoice.id}"
+    expect(page).to have_content("Invoice id: #{@invoice.id} Show Page")
+  end
+
+  it 'has details about the invoice' do
+    visit "/admin/invoices/#{@invoice.id}"
+    
+    expect(page).to have_content('id: ' + @invoice.id.to_s)
+    expect(page).to have_content('customer_id: ' + @invoice.customer_id.to_s)
+    expect(page).to have_content('status: ' + @invoice.status)
+    expect(page).to have_content('created_at: ' + @invoice.created_at.to_s)
+    expect(page).to have_content('updated_at: ' + @invoice.updated_at.to_s)
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -7,4 +7,24 @@ RSpec.describe Invoice, type: :model do
     it {should have_many :invoice_items}
     it {should have_many(:items).through(:invoice_items)}
   end
+
+  describe '.incomplete' do
+    it 'returns an array of incomplete invoices' do
+      @customer = create(:customer)
+      @invoice1 = create(:invoice, customer_id: @customer.id)
+      @invoice2 = create(:invoice, customer_id: @customer.id)
+      @invoice3 = create(:invoice, customer_id: @customer.id)
+      @invoice4 = create(:invoice, customer_id: @customer.id)
+      @invoice5 = create(:invoice, customer_id: @customer.id)
+      @merchant = create(:merchant)
+      @item = create(:item, merchant_id: @merchant.id)
+      #StatusKey: 0 => packaged, 1 => pending, 2 => shipped
+      @invoice_item1 = create(:invoice_item, invoice_id: @invoice1.id, item_id: @item.id, status: 2)
+      @invoice_item2 = create(:invoice_item, invoice_id: @invoice2.id, item_id: @item.id, status: 0)
+      @invoice_item3 = create(:invoice_item, invoice_id: @invoice3.id, item_id: @item.id, status: 2)
+      @invoice_item4 = create(:invoice_item, invoice_id: @invoice4.id, item_id: @item.id, status: 0)
+      @invoice_item5 = create(:invoice_item, invoice_id: @invoice5.id, item_id: @item.id, status: 1)
+      expect(Invoice.incomplete.sort).to eq([@invoice2, @invoice4, @invoice5]) 
+    end
+  end
 end


### PR DESCRIPTION
This completes user story 22, which has the admin dashboard list all the incomplete invoices. Each of those items in the list is a link to a show page, which I also routed and created. 

The active record query for incomplete invoices:
 (for context invoice_item enum status 2 is the only 'shipped'  status)
![Screenshot 2023-02-23 at 9 54 28 PM](https://user-images.githubusercontent.com/80081206/221095361-aa7b3f69-f80f-4f60-bfd7-19470de3a762.png)
