### PR TITLE
Matt test fix

### DIFF
--- a/app/views/merchants/items.html.erb
+++ b/app/views/merchants/items.html.erb
@@ -5,7 +5,7 @@
 <br>
 
 <h2>Top 5 Most Popular Items (By Revenue)</h2>
-<div id="top_5_items">
+<div id = "top_5_items">
   <% @top_5_items.each do |item| %>
     <li><%= link_to item.name, "/merchants/#{item.merchant_id}/items/#{item.id}" %>: <%= number_to_currency(item.revenue) %></li>
     <li>Top selling date for <%= item.name %> was <%= item.top_item_day.created_at.strftime("%B %e, %Y") %></li>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :item do
     name {Faker::Lorem.sentence(word_count: 2)}
-    description {Faker::Books::Dune.quote}
+    description {Faker::Lorem.sentence(word_count:17)}
     unit_price {Faker::Number.number(digits: 5)}
     merchant_id {Faker::Number.within(range: 1..100)}
   end

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -29,7 +29,7 @@ describe 'Admin Invoices index page' do
 
       it "I see a list of all invoice ids in the system and each ID linkes to the admin invoice show page" do
         visit admin_invoices_path
-      
+ 
         expect(page).to have_link("#{invoice_2.id}")
         expect(page).to have_link("#{invoice_3.id}")
         expect(page).to have_link("#{invoice_4.id}")

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -13,7 +13,7 @@ describe 'Admin Invoices show page' do
   
       it "I see information related to that invoice including: - Invoice id - Invoice status - Invoice created_at date in the format 'Monday, July 18, 2019' - Customer first and last name" do
         visit admin_invoice_path(invoice_2)
-      
+  
         expect(page).to have_content("#{invoice_2.id}")
         expect(page).to have_content("#{invoice_2.status}")
         expect(page).to have_content("#{invoice_2.created_at.strftime("%A, %B %e, %Y")}")

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -46,6 +46,7 @@ describe 'edit admin merchant page' do
 
         it 'should have the same merchant id' do
           expect(@merchant.id).to eq(@merchant_original_id)
+  
         end
 
         it 'should not have the old merchant information' do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -91,7 +91,7 @@ describe 'Admin Merchants index page' do
 
       it "I see the date with the most revenue for each merchant with a label 'Top selling date for <merchant name> was <date with most sales>'" do
         visit admin_merchants_path
-  
+       
         expect(page).to have_content("Top selling date for #{merchant_2.name} was #{invoice_2.created_at.strftime("%A, %B %e, %Y")}")
         expect(page).to have_content("Top selling date for #{merchant_3.name} was #{invoice_3.created_at.strftime("%A, %B %e, %Y")}")
       end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -11,7 +11,7 @@ describe 'Admin Merchants show page' do
     describe 'When I click on the name of a merchant from the admin merchants index page' do
       it "I am taken to that merchant's admin show page (/admin/merchants/merchant_id) and I see the name of that merchant" do
         visit admin_merchants_path
-        
+   
         click_link(@merchant_1.name.to_s)
 
         expect(current_path).to eq(admin_merchant_path(@merchant_1))

--- a/spec/features/merchants/item_index_spec.rb
+++ b/spec/features/merchants/item_index_spec.rb
@@ -152,24 +152,24 @@ RSpec.describe "Merchant Items Index", type: :feature do
           transaction_8 = create(:transaction, invoice_id: invoice_8.id, result: 'success')
 
           visit "/merchants/#{merchant_1.id}/items"
+   
           expect(page).to have_content("Top 5 Most Popular Items (By Revenue)")
           
-          within "#top_5_items" do
-            expect(page).to have_content("#{item_1.name}")
-            expect(page).to have_content("#{item_2.name}")
-            expect(page).to have_content("#{item_3.name}")
-            expect(page).to have_content("#{item_4.name}")
-            expect(page).to have_content("#{item_6.name}")
+          within("#top_5_items") do
+            expect(page).to have_link("#{item_1.name}")
+            expect(page).to have_link("#{item_2.name}")
+            expect(page).to have_link("#{item_3.name}")
+            expect(page).to have_link("#{item_4.name}")
+            expect(page).to have_link("#{item_6.name}")
             expect(page).to_not have_content("#{item_5.name}")
             expect(page).to_not have_content("#{item_7.name}")
             expect(page).to_not have_content("#{item_8.name}")
             expect(item_1.name).to appear_before(item_2.name)
             expect(item_2.name).to appear_before(item_3.name)
             expect(item_4.name).to appear_before(item_6.name)
+            click_on "#{item_1.name}"
           end
 
-          click_on "#{item_1.name}"
-          
           expect(current_path).to eq("/merchants/#{merchant_1.id}/items/#{item_1.id}")
         end
       end
@@ -214,10 +214,10 @@ RSpec.describe "Merchant Items Index", type: :feature do
         visit "/merchants/#{merchant_1.id}/items"
   
         within "#top_5_items" do
-          save_and_open_page
+         
           expect(page).to have_content("Top selling date for #{item_1.name} was January 28, 2019")
         end
       end
-    
+    end
   end
 end


### PR DESCRIPTION
Refactor features merchant item index spec to include 'click button' in within block preventing capybara finding duplicate buttons/links. Revert item factory faker description to sentence to prevent tests failing from finding duplicate content due to small sample size. 