### PR TITLE
Item show fix

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,7 +10,7 @@ class ItemsController < ApplicationController
 
   def show
     @merchant = Merchant.find(params[:merchant_id])
-    @items = @merchant.items
+    @item = @merchant.items.find(params[:id])
   end
 
   def new

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -2,6 +2,4 @@ class MerchantsController < ApplicationController
   def dashboard
     @merchant = Merchant.find(params[:merchant_id])
   end
-
-
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,8 +1,7 @@
-<h1>Merchant's Items Show Page</h1>
+<h1>Merchant's Item Show Page</h1>
 
-<% @items.each do |item| %>
-  <h3><%= item.name %></h3>
-  <p><%= link_to "Update #{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}/edit" %></p>
-  <p><%= item.description %></p>
-  <p><%= format_price(item.unit_price) %></p>
-<% end %>
+
+  <h3><%= @item.name %></h3>
+  <p>Description: <%= @item.description %></p>
+  <p>Current Price: <%= format_price(@item.unit_price) %></p>
+  <p><%= link_to "Update #{@item.name}", "/merchants/#{@merchant.id}/items/#{@item.id}/edit" %></p>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe "Merchant Items Index", type: :feature do
         expect(page).to have_content(item1.description)
         expect(page).to have_content(item1.unit_price.to_f / 100)
 
+        expect(page).to_not have_content(item2.name)
+        expect(page).to_not have_content(item2.description)
+        expect(page).to_not have_content(item2.unit_price)
         expect(page).to_not have_content(item3.name)
         expect(page).to_not have_content(item3.description)
         expect(page).to_not have_content(item3.unit_price)

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe "Merchant Items Index", type: :feature do
 
         expect(page).to_not have_content(item2.name)
         expect(page).to_not have_content(item2.description)
-        expect(page).to_not have_content(item2.unit_price)
+        expect(page).to_not have_content(item2.unit_price.to_f / 100)
         expect(page).to_not have_content(item3.name)
         expect(page).to_not have_content(item3.description)
-        expect(page).to_not have_content(item3.unit_price)
+        expect(page).to_not have_content(item3.unit_price.to_f / 100)
       end
     end
 


### PR DESCRIPTION
1. Modifies merchant item show page to only include one item. Adds formatting.
2. Edit's test in merchant item index spec to better reflect functionality
3. Edit's item show action to only display one item in show page